### PR TITLE
add Utah to test handling of h character

### DIFF
--- a/metaphone.csv
+++ b/metaphone.csv
@@ -24,3 +24,4 @@ Xhot,XHT
 Xnot,SNT
 g,K
 8 queens,KNS
+Utah,UT


### PR DESCRIPTION
The jellyfish Python implementation doesn't handle the h character correctly. It failed on "Utah" so we'll make sure it works correctly.